### PR TITLE
update to support jdk 21 and latest jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.bigarmor</groupId>
     <artifactId>swagger-2-jakarta-maven-plugin</artifactId>
-    <version>3.1.9-SNAPSHOT</version>
+    <version>3.1.10-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>Swagger Maven Plugin</name>
     <description>
@@ -52,7 +52,7 @@
 
     <properties>
         <!-- Settings -->
-        <java.version>1.6</java.version>
+        <java.version>8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
@@ -62,8 +62,8 @@
 
         <!-- Dependency versions -->
         <maven.version>2.2.1</maven.version>
-        <swagger.version>1.5.21</swagger.version>
-        <jackson.version>2.8.9</jackson.version>
+        <swagger.version>1.6.14</swagger.version>
+        <jackson.version>2.17.2</jackson.version>
         <log4j.version>1.2.16</log4j.version>
         <handlebars.version>1.3.2</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>
@@ -93,7 +93,7 @@
         <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
         <version.plexus-javadoc>1.0</version.plexus-javadoc>
         <version.slf4j-nop>1.7.25</version.slf4j-nop>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>2.0.0</kotlin.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -437,6 +437,7 @@ public abstract class AbstractReader {
             //technically should not be possible at this point, added to be safe
             if (responses != null) {
                 responses.remove("200");
+                operation.getResponsesObject().remove("200");
             }
         }
     }

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -323,6 +323,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         if (operation.getResponses() != null && operation.getResponses().size() == 1) {
             String currentKey = operation.getResponses().keySet().iterator().next();
             Response oldResponse = operation.getResponses().remove(currentKey);
+            operation.getResponsesObject().remove(currentKey);
             if (StringUtils.isNotEmpty(reason)) {
                 oldResponse.setDescription(reason);
             }

--- a/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringMVCResponseStatusTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringMVCResponseStatusTest.java
@@ -69,7 +69,7 @@ public class SpringMVCResponseStatusTest {
 
     @Test
     public void testAPIResponse() throws GenerateException {
-        testMethod("/getString_ApiResponse_202_409", HttpMethod.GET,
+         testMethod("/getString_ApiResponse_202_409", HttpMethod.GET,
               ImmutableMap.of(
                     HttpStatus.ACCEPTED,
                     new Response().description(ACCEPTED_OPERATION_DESCRIPTION).responseSchema(RETURN_TYPE_STRING),

--- a/src/test/java/com/wordnik/sample/TestVendorExtension.java
+++ b/src/test/java/com/wordnik/sample/TestVendorExtension.java
@@ -35,6 +35,7 @@ public class TestVendorExtension extends AbstractSwaggerExtension {
             value.setDescription(RESPONSE_DESCRIPTION);
             map.put(RESPONSE_STATUS_401, value);
             operation.setResponses(map);
+            operation.addResponse(RESPONSE_STATUS_401, value);
         }
 
         if (chain.hasNext()) {

--- a/src/test/java/com/wordnik/sample/VendorExtensionWithoutReader.java
+++ b/src/test/java/com/wordnik/sample/VendorExtensionWithoutReader.java
@@ -32,11 +32,12 @@ public class VendorExtensionWithoutReader extends AbstractSwaggerExtension {
             value.setDescription(RESPONSE_DESCRIPTION);
             map.put(RESPONSE_STATUS_501, value);
             operation.setResponses(map);
+            operation.addResponse(RESPONSE_STATUS_501, value);
         }
 
         if (chain.hasNext()) {
             chain.next().decorateOperation(operation, method, chain);
         }
     }
-    
+
 }


### PR DESCRIPTION
Current YAML serialization still uses javax serialization. Updated dependencies of jackson and swagger and fixed tests where they broke due to changes in swagger.

Tested on a JDK 21 project 